### PR TITLE
Provide props from <Loc/> to inner <Text/>

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-    "presets": ["es2015", "react"]
+    "presets": ["es2015", "react"],
+    "plugins": ["transform-object-rest-spread"]
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.0",
+    "babel-plugin-transform-object-rest-spread": "^6.22.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0"
   },

--- a/src/LocPresentationalRN.js
+++ b/src/LocPresentationalRN.js
@@ -2,8 +2,8 @@ import translate from 'translatr'
 import React from 'react'
 import { Text } from 'react-native'
 
-const Loc = ({ currentLanguage, locKey, number, dictionary }) => {
-    return <Text>
+const Loc = ({ currentLanguage, locKey, number, dictionary, dispatch, ...rest }) => {
+    return <Text { ...rest }>
         { translate( dictionary, currentLanguage, locKey, number ) }
     </Text>
 }


### PR DESCRIPTION
React Native implementation of [this PR](https://github.com/derzunov/redux-react-i18n/pull/2) to redux-react-i18n module.

---

This PR avoids redundant wrappers, by forwarding props (e.g. `style` or `className`) from `<Loc/>` to his child.
So we can apply it right on `<Loc/>`:

Before:
```js
<Text style='color: red'><Loc locKey="PageTitle"/></Text>
```

After:
```js
<Loc locKey="PageTitle" style='color: red'/>
```